### PR TITLE
Set version to 1.0.0 of under new org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mytosbio/sensirion-hdlc",
-    "version": "1.0.0-5",
+    "version": "1.0.0",
     "license": "MIT",
     "author": "Mytos Bio",
     "main": "dist/index.js",


### PR DESCRIPTION
Version tag had undocumented suffix. This PR removes the suffix and republishes under simply "1.0.0"